### PR TITLE
Feature/ 계좌 내역 페이지 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,13 +41,13 @@ export default function RootLayout() {
       const inSavingsConfirmGroup = segments[0] === 'savings-confirm';
       const inMealInfoGroup = segments[0] === 'meal-info';
       const inChatListGroup = segments[0] === 'chatlist';
-
+      const accountHistory = segments[0] === 'account-history';
 
       if (!isAuthenticated && !inAuthGroup) {
         // 인증 안됨 → 로그인으로
         router.replace('/(auth)/sign-in');
 
-      } else if (isAuthenticated && !inMainGroup && !inMealsGroup && !inMealGroup && !inTimetableGroup && !inGroupsGroup && !inChatGroup && !inSplitBillGroup && !inPaymentConfirmGroup && !inSavingsConfirmGroup && !inMealInfoGroup && !inChatListGroup) {
+      } else if (isAuthenticated && !inMainGroup && !inMealsGroup && !inMealGroup && !inTimetableGroup && !inGroupsGroup && !inChatGroup && !inSplitBillGroup && !inPaymentConfirmGroup && !inSavingsConfirmGroup && !inMealInfoGroup && !inChatListGroup && !accountHistory) {
         // 인증됨 + 허용된 그룹이 아님 → 메인으로
         router.replace('/(main)');
       }
@@ -84,6 +84,7 @@ export default function RootLayout() {
         <Stack.Screen name="savings-confirm" />
         <Stack.Screen name="meal-info" />
         <Stack.Screen name="chatlist" />
+        <Stack.Screen name="account-history" />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/account-history/_layout.tsx
+++ b/app/account-history/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router';
+
+export default function AccountHistoryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+}

--- a/app/account-history/index.tsx
+++ b/app/account-history/index.tsx
@@ -1,0 +1,5 @@
+import { AccountHistoryScreen } from '@/src/features/account-history/ui/AccountHistoryScreen';
+
+export default function AccountHistoryPage() {
+  return <AccountHistoryScreen />;
+}

--- a/src/features/account-history/api/accountHistoryApi.ts
+++ b/src/features/account-history/api/accountHistoryApi.ts
@@ -1,0 +1,133 @@
+import { apiClient } from '@/src/shared/api/client';
+import type { AccountHistoryRequest, AccountHistoryResponse, TransactionHistoryDto } from '../model/types';
+
+export const accountHistoryApi = {
+  // 실제 API 호출
+  getAccountHistory: async (request: AccountHistoryRequest) => {
+    const queryParams = new URLSearchParams({
+      startDate: request.startDate,
+      endDate: request.endDate,
+    });
+
+    return apiClient.get<AccountHistoryResponse>(`/account/history?${queryParams}`);
+  },
+
+  // 개발용 Mock API
+  getMockAccountHistory: async (request: AccountHistoryRequest): Promise<{ success: boolean; data: AccountHistoryResponse; error?: string }> => {
+    await new Promise(resolve => setTimeout(resolve, 800));
+    
+    try {
+      const mockData: TransactionHistoryDto[] = [
+        {
+          transactorName: "이지민",
+          transactionUniqueNo: "59",
+          transactionDate: "20250827",
+          transactionTime: "102427",
+          transactionTypeName: "입금(이체)",
+          transactionBalance: "12000",
+          transactionAfterBalance: "88000",
+          eventTitle: "🍕 피자 먹으러 가실 분~"
+        },
+        {
+          transactorName: "박재은",
+          transactionUniqueNo: "60",
+          transactionDate: "20250827",
+          transactionTime: "143520",
+          transactionTypeName: "출금(이체)",
+          transactionBalance: "5000",
+          transactionAfterBalance: "83000",
+          eventTitle: "🍜 라면 끓여먹을 사람!"
+        },
+        {
+          transactorName: "김민수",
+          transactionUniqueNo: "61",
+          transactionDate: "20250826",
+          transactionTime: "191245",
+          transactionTypeName: "입금(이체)",
+          transactionBalance: "3000",
+          transactionAfterBalance: "86000",
+          eventTitle: "🍱 학식 같이 먹어요!"
+        },
+        {
+          transactorName: "최유진",
+          transactionUniqueNo: "62",
+          transactionDate: "20250826",
+          transactionTime: "120000",
+          transactionTypeName: "출금(이체)",
+          transactionBalance: "8000",
+          transactionAfterBalance: "78000",
+          eventTitle: "🥗 샐러드 같이 드실분"
+        },
+        {
+          transactorName: "장동건",
+          transactionUniqueNo: "63",
+          transactionDate: "20250825",
+          transactionTime: "200030",
+          transactionTypeName: "입금(이체)",
+          transactionBalance: "6000",
+          transactionAfterBalance: "84000",
+          eventTitle: "🍗 치킨 파티 하실분!!"
+        },
+        {
+          transactorName: "정수아",
+          transactionUniqueNo: "64",
+          transactionDate: "20250825",
+          transactionTime: "113000",
+          transactionTypeName: "출금(이체)",
+          transactionBalance: "4500",
+          transactionAfterBalance: "79500",
+          eventTitle: "🍱 기숙사 같이 밥먹기"
+        },
+        {
+          transactorName: "윤도현",
+          transactionUniqueNo: "65",
+          transactionDate: "20250824",
+          transactionTime: "155500",
+          transactionTypeName: "입금(이체)",
+          transactionBalance: "7500",
+          transactionAfterBalance: "87000",
+          eventTitle: "☕ 카페 스터디"
+        },
+        {
+          transactorName: "김하늘",
+          transactionUniqueNo: "66",
+          transactionDate: "20250824",
+          transactionTime: "140000",
+          transactionTypeName: "출금(이체)",
+          transactionBalance: "2500",
+          transactionAfterBalance: "76500",
+          eventTitle: "📚 스터디 모임"
+        },
+      ];
+
+      // 날짜 범위 필터링
+      const filteredData = mockData.filter(item => 
+        item.transactionDate >= request.startDate && 
+        item.transactionDate <= request.endDate
+      );
+
+      // 날짜/시간 순으로 정렬 (최신순)
+      const sortedData = filteredData.sort((a, b) => {
+        const dateTimeA = a.transactionDate + a.transactionTime;
+        const dateTimeB = b.transactionDate + b.transactionTime;
+        return dateTimeB.localeCompare(dateTimeA);
+      });
+
+      const response: AccountHistoryResponse = {
+        totalCount: sortedData.length,
+        transactionHistoryDtoList: sortedData
+      };
+
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: { totalCount: 0, transactionHistoryDtoList: [] },
+        error: error instanceof Error ? error.message : '데이터를 불러오는데 실패했습니다'
+      };
+    }
+  }
+};

--- a/src/features/account-history/model/accountHistoryStore.ts
+++ b/src/features/account-history/model/accountHistoryStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { accountHistoryApi } from '../api/accountHistoryApi';
-import type { DateRange, TransactionHistoryDto, FormattedTransaction } from './types';
+import type { DateRange, TransactionHistoryDto, FormattedTransaction, DateSection } from './types';
 
 interface AccountHistoryState {
   // 데이터
@@ -26,6 +26,9 @@ interface AccountHistoryActions {
   
   // 포맷팅된 거래 내역 반환
   getFormattedTransactions: () => FormattedTransaction[];
+  
+  // 날짜별로 그룹핑된 거래 내역 반환
+  getGroupedTransactions: () => DateSection[];
 }
 
 type AccountHistoryStore = AccountHistoryState & AccountHistoryActions;
@@ -67,6 +70,15 @@ const formatTime = (timeStr: string): string => {
   const hour = timeStr.substring(0, 2);
   const minute = timeStr.substring(2, 4);
   return `${hour}:${minute}`;
+};
+
+// 날짜 전체 포맷팅 (YYYYMMDD → YYYY년 MM월 DD일)
+const formatFullDate = (dateStr: string): string => {
+  if (dateStr.length !== 8) return dateStr;
+  const year = dateStr.substring(0, 4);
+  const month = parseInt(dateStr.substring(4, 6));
+  const day = parseInt(dateStr.substring(6, 8));
+  return `${year}년 ${String(month).padStart(2, '0')}월 ${String(day).padStart(2, '0')}일`;
 };
 
 export const useAccountHistoryStore = create<AccountHistoryStore>((set, get) => ({
@@ -133,6 +145,30 @@ export const useAccountHistoryStore = create<AccountHistoryStore>((set, get) => 
       isLoading: false,
       error: null,
     });
+  },
+
+  // 날짜별로 그룹핑된 거래 내역 반환
+  getGroupedTransactions: (): DateSection[] => {
+    const formattedTransactions = get().getFormattedTransactions();
+    
+    // 날짜별로 그룹핑
+    const grouped: { [key: string]: FormattedTransaction[] } = {};
+    
+    formattedTransactions.forEach(transaction => {
+      const dateKey = transaction.transactionDate;
+      if (!grouped[dateKey]) {
+        grouped[dateKey] = [];
+      }
+      grouped[dateKey].push(transaction);
+    });
+    
+    // DateSection 배열로 변환하고 날짜별로 정렬 (최신순)
+    return Object.keys(grouped)
+      .sort((a, b) => b.localeCompare(a)) // 내림차순 정렬 (최신 날짜 먼저)
+      .map(dateKey => ({
+        title: formatFullDate(dateKey),
+        data: grouped[dateKey]
+      }));
   },
 
   // 에러 초기화

--- a/src/features/account-history/model/accountHistoryStore.ts
+++ b/src/features/account-history/model/accountHistoryStore.ts
@@ -1,0 +1,142 @@
+import { create } from 'zustand';
+import { accountHistoryApi } from '../api/accountHistoryApi';
+import type { DateRange, TransactionHistoryDto, FormattedTransaction } from './types';
+
+interface AccountHistoryState {
+  // 데이터
+  transactions: TransactionHistoryDto[];
+  totalCount: number;
+  dateRange: DateRange;
+  
+  // 상태
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface AccountHistoryActions {
+  // 데이터 로드
+  loadAccountHistory: () => Promise<void>;
+  
+  // 날짜 범위 변경
+  setDateRange: (dateRange: DateRange) => void;
+  
+  // 유틸리티
+  reset: () => void;
+  clearError: () => void;
+  
+  // 포맷팅된 거래 내역 반환
+  getFormattedTransactions: () => FormattedTransaction[];
+}
+
+type AccountHistoryStore = AccountHistoryState & AccountHistoryActions;
+
+// 기본 날짜 범위 (최근 30일)
+const getDefaultDateRange = (): DateRange => {
+  const today = new Date();
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(today.getDate() - 30);
+  
+  return {
+    startDate: thirtyDaysAgo.toISOString().slice(0, 10).replace(/-/g, ''), // YYYYMMDD
+    endDate: today.toISOString().slice(0, 10).replace(/-/g, ''), // YYYYMMDD
+  };
+};
+
+// 거래 유형이 입금인지 확인하는 헬퍼 함수
+const isDepositTransaction = (typeName: string): boolean => {
+  return typeName.includes('입금');
+};
+
+// 금액 포맷팅 (천 단위 콤마)
+const formatAmount = (amount: string): string => {
+  const num = parseInt(amount, 10);
+  return num.toLocaleString();
+};
+
+// 날짜 포맷팅 (YYYYMMDD → MM월 DD일)
+const formatDate = (dateStr: string): string => {
+  if (dateStr.length !== 8) return dateStr;
+  const month = parseInt(dateStr.substring(4, 6));
+  const day = parseInt(dateStr.substring(6, 8));
+  return `${month}월 ${day}일`;
+};
+
+// 시간 포맷팅 (HHMMSS → HH:MM)
+const formatTime = (timeStr: string): string => {
+  if (timeStr.length < 4) return timeStr;
+  const hour = timeStr.substring(0, 2);
+  const minute = timeStr.substring(2, 4);
+  return `${hour}:${minute}`;
+};
+
+export const useAccountHistoryStore = create<AccountHistoryStore>((set, get) => ({
+  // 초기 상태
+  transactions: [],
+  totalCount: 0,
+  dateRange: getDefaultDateRange(),
+  isLoading: false,
+  error: null,
+
+  // 계좌 내역 로드
+  loadAccountHistory: async () => {
+    const { dateRange } = get();
+    
+    set({ isLoading: true, error: null });
+
+    try {
+      // 개발 중에는 Mock API 사용
+      const response = await accountHistoryApi.getMockAccountHistory(dateRange);
+
+      if (response.success && response.data) {
+        set({ 
+          transactions: response.data.transactionHistoryDtoList,
+          totalCount: response.data.totalCount,
+          isLoading: false 
+        });
+      } else {
+        throw new Error(response.error || '데이터를 불러오는데 실패했습니다');
+      }
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : '네트워크 오류가 발생했습니다',
+        isLoading: false
+      });
+    }
+  },
+
+  // 날짜 범위 설정 및 데이터 재로드
+  setDateRange: (newDateRange: DateRange) => {
+    set({ dateRange: newDateRange });
+    get().loadAccountHistory();
+  },
+
+  // 포맷팅된 거래 내역 반환
+  getFormattedTransactions: (): FormattedTransaction[] => {
+    const { transactions } = get();
+    
+    return transactions.map(transaction => ({
+      ...transaction,
+      isDeposit: isDepositTransaction(transaction.transactionTypeName),
+      formattedAmount: (isDepositTransaction(transaction.transactionTypeName) ? '+' : '-') 
+                      + formatAmount(transaction.transactionBalance),
+      formattedDate: formatDate(transaction.transactionDate),
+      formattedTime: formatTime(transaction.transactionTime),
+    }));
+  },
+
+  // 상태 초기화
+  reset: () => {
+    set({
+      transactions: [],
+      totalCount: 0,
+      dateRange: getDefaultDateRange(),
+      isLoading: false,
+      error: null,
+    });
+  },
+
+  // 에러 초기화
+  clearError: () => {
+    set({ error: null });
+  },
+}));

--- a/src/features/account-history/model/types.ts
+++ b/src/features/account-history/model/types.ts
@@ -1,0 +1,37 @@
+// 거래 내역 API 요청 타입
+export interface AccountHistoryRequest {
+  startDate: string;  // YYYYMMDD 형식
+  endDate: string;    // YYYYMMDD 형식
+}
+
+// 거래 내역 개별 아이템 타입
+export interface TransactionHistoryDto {
+  transactorName: string;           // 거래 상대방 이름
+  transactionUniqueNo: string;      // 거래 고유 번호
+  transactionDate: string;          // 거래 날짜 (YYYYMMDD)
+  transactionTime: string;          // 거래 시간 (HHMMSS)
+  transactionTypeName: string;      // 거래 유형 ("입금(이체)", "출금(이체)" 등)
+  transactionBalance: string;       // 거래 금액
+  transactionAfterBalance: string;  // 거래 후 잔액
+  eventTitle?: string;              // 관련 이벤트 제목 (밥약/모임)
+}
+
+// 거래 내역 API 응답 타입
+export interface AccountHistoryResponse {
+  totalCount: number;
+  transactionHistoryDtoList: TransactionHistoryDto[];
+}
+
+// 날짜 범위 타입
+export interface DateRange {
+  startDate: string;  // YYYYMMDD
+  endDate: string;    // YYYYMMDD
+}
+
+// 포맷팅된 거래 정보 (화면 표시용)
+export interface FormattedTransaction extends TransactionHistoryDto {
+  isDeposit: boolean;        // 입금 여부
+  formattedAmount: string;   // +/- 포함된 금액 표시
+  formattedDate: string;     // MM월 DD일 형식
+  formattedTime: string;     // HH:MM 형식
+}

--- a/src/features/account-history/model/types.ts
+++ b/src/features/account-history/model/types.ts
@@ -35,3 +35,9 @@ export interface FormattedTransaction extends TransactionHistoryDto {
   formattedDate: string;     // MM월 DD일 형식
   formattedTime: string;     // HH:MM 형식
 }
+
+// 날짜별 그룹핑된 섹션 데이터
+export interface DateSection {
+  title: string;                    // "2024년 08월 27일"
+  data: FormattedTransaction[];     // 해당 날짜의 거래 내역들
+}

--- a/src/features/account-history/ui/AccountHistoryScreen.tsx
+++ b/src/features/account-history/ui/AccountHistoryScreen.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect } from 'react';
+import { View, StyleSheet, Text, FlatList, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useAccountHistoryStore } from '../model/accountHistoryStore';
+import { AccountHistoryHeader } from './components/AccountHistoryHeader';
+import { DateRangeSelector } from './components/DateRangeSelector';
+import { TransactionItem } from './components/TransactionItem';
+import type { FormattedTransaction } from '../model/types';
+
+export const AccountHistoryScreen: React.FC = () => {
+  const insets = useSafeAreaInsets();
+  const {
+    dateRange,
+    totalCount,
+    isLoading,
+    error,
+    loadAccountHistory,
+    setDateRange,
+    getFormattedTransactions,
+    clearError,
+  } = useAccountHistoryStore();
+
+  // 컴포넌트 마운트 시 데이터 로드
+  useEffect(() => {
+    loadAccountHistory();
+  }, []);
+
+  // 에러 처리
+  useEffect(() => {
+    if (error) {
+      Alert.alert('오류', error, [
+        { text: '확인', onPress: clearError }
+      ]);
+    }
+  }, [error]);
+
+  // 포맷팅된 거래 내역 가져오기
+  const formattedTransactions = getFormattedTransactions();
+
+  // 빈 목록 렌더링
+  const renderEmptyList = () => (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyText}>
+        {isLoading ? '거래 내역을 불러오는 중...' : '선택한 기간에 거래 내역이 없습니다'}
+      </Text>
+    </View>
+  );
+
+  // 거래 아이템 렌더링
+  const renderTransactionItem = ({ item }: { item: FormattedTransaction }) => (
+    <TransactionItem transaction={item} />
+  );
+
+  return (
+    <View style={styles.container}>
+      {/* 헤더 */}
+      <AccountHistoryHeader />
+
+      {/* 날짜 선택 */}
+      <DateRangeSelector
+        dateRange={dateRange}
+        onDateRangeChange={setDateRange}
+      />
+
+      {/* 거래 건수 표시 */}
+      <View style={styles.countContainer}>
+        <Text style={styles.countText}>
+          총 {totalCount}건의 거래
+        </Text>
+      </View>
+
+      {/* 거래 목록 */}
+      <FlatList
+        data={formattedTransactions}
+        keyExtractor={(item) => item.transactionUniqueNo}
+        renderItem={renderTransactionItem}
+        ListEmptyComponent={renderEmptyList}
+        contentContainerStyle={[
+          styles.listContainer,
+          { paddingBottom: Math.max(20, insets.bottom) }
+        ]}
+        showsVerticalScrollIndicator={false}
+        refreshing={isLoading}
+        onRefresh={loadAccountHistory}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  countContainer: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    backgroundColor: 'white',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  countText: {
+    fontSize: 14,
+    color: '#6B7280',
+    fontWeight: '500',
+  },
+  listContainer: {
+    flexGrow: 1,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 60,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#9CA3AF',
+    textAlign: 'center',
+  },
+});

--- a/src/features/account-history/ui/AccountHistoryScreen.tsx
+++ b/src/features/account-history/ui/AccountHistoryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View, StyleSheet, Text, SectionList, Alert } from 'react-native';
+import { View, StyleSheet, Text, SectionList, Alert, Dimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAccountHistoryStore } from '../model/accountHistoryStore';
 import { AccountHistoryHeader } from './components/AccountHistoryHeader';
@@ -9,6 +9,11 @@ import type { FormattedTransaction, DateSection } from '../model/types';
 
 export const AccountHistoryScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
+  
+  // 화면 높이에서 하단 탭바 높이(83px)를 뺀 사용 가능한 높이 계산
+  const screenHeight = Dimensions.get('window').height;
+  const tabBarHeight = 83;
+  const availableHeight = screenHeight - tabBarHeight;
   const {
     dateRange,
     totalCount,
@@ -59,7 +64,7 @@ export const AccountHistoryScreen: React.FC = () => {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { height: availableHeight }]}>
       {/* 헤더 */}
       <AccountHistoryHeader />
 

--- a/src/features/account-history/ui/AccountHistoryScreen.tsx
+++ b/src/features/account-history/ui/AccountHistoryScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
-import { View, StyleSheet, Text, FlatList, Alert } from 'react-native';
+import { View, StyleSheet, Text, SectionList, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAccountHistoryStore } from '../model/accountHistoryStore';
 import { AccountHistoryHeader } from './components/AccountHistoryHeader';
 import { DateRangeSelector } from './components/DateRangeSelector';
 import { TransactionItem } from './components/TransactionItem';
-import type { FormattedTransaction } from '../model/types';
+import type { FormattedTransaction, DateSection } from '../model/types';
 
 export const AccountHistoryScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
@@ -16,7 +16,7 @@ export const AccountHistoryScreen: React.FC = () => {
     error,
     loadAccountHistory,
     setDateRange,
-    getFormattedTransactions,
+    getGroupedTransactions,
     clearError,
   } = useAccountHistoryStore();
 
@@ -34,8 +34,8 @@ export const AccountHistoryScreen: React.FC = () => {
     }
   }, [error]);
 
-  // 포맷팅된 거래 내역 가져오기
-  const formattedTransactions = getFormattedTransactions();
+  // 날짜별로 그룹핑된 거래 내역 가져오기
+  const groupedTransactions = getGroupedTransactions();
 
   // 빈 목록 렌더링
   const renderEmptyList = () => (
@@ -49,6 +49,13 @@ export const AccountHistoryScreen: React.FC = () => {
   // 거래 아이템 렌더링
   const renderTransactionItem = ({ item }: { item: FormattedTransaction }) => (
     <TransactionItem transaction={item} />
+  );
+
+  // 날짜 헤더 렌더링
+  const renderSectionHeader = ({ section }: { section: DateSection }) => (
+    <View style={styles.dateHeader}>
+      <Text style={styles.dateHeaderText}>{section.title}</Text>
+    </View>
   );
 
   return (
@@ -70,10 +77,11 @@ export const AccountHistoryScreen: React.FC = () => {
       </View>
 
       {/* 거래 목록 */}
-      <FlatList
-        data={formattedTransactions}
+      <SectionList
+        sections={groupedTransactions}
         keyExtractor={(item) => item.transactionUniqueNo}
         renderItem={renderTransactionItem}
+        renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={renderEmptyList}
         contentContainerStyle={[
           styles.listContainer,
@@ -82,6 +90,7 @@ export const AccountHistoryScreen: React.FC = () => {
         showsVerticalScrollIndicator={false}
         refreshing={isLoading}
         onRefresh={loadAccountHistory}
+        stickySectionHeadersEnabled={false}
       />
     </View>
   );
@@ -117,5 +126,17 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#9CA3AF',
     textAlign: 'center',
+  },
+  dateHeader: {
+    backgroundColor: '#F3F4F6',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  dateHeaderText: {
+    fontSize: 14,
+    color: '#6B7280',
+    fontWeight: '600',
   },
 });

--- a/src/features/account-history/ui/components/AccountHistoryHeader.tsx
+++ b/src/features/account-history/ui/components/AccountHistoryHeader.tsx
@@ -1,0 +1,63 @@
+import { router } from 'expo-router';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface AccountHistoryHeaderProps {
+  title?: string;
+}
+
+export const AccountHistoryHeader: React.FC<AccountHistoryHeaderProps> = ({
+  title = '내 결제 확인하기'
+}) => {
+  const handleBackPress = () => {
+    router.back();
+  };
+
+  return (
+    <View style={styles.header}>
+      <TouchableOpacity 
+        style={styles.backButton}
+        onPress={handleBackPress}
+      >
+        <Text style={styles.backButtonText}>‹</Text>
+      </TouchableOpacity>
+      
+      <Text style={styles.title}>{title}</Text>
+      
+      <View style={styles.placeholder} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: 60,
+    paddingBottom: 20,
+    paddingHorizontal: 20,
+    backgroundColor: 'white',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backButtonText: {
+    fontSize: 24,
+    color: '#374151',
+    fontWeight: '300',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  placeholder: {
+    width: 40,
+  },
+});

--- a/src/features/account-history/ui/components/DateRangeSelector.tsx
+++ b/src/features/account-history/ui/components/DateRangeSelector.tsx
@@ -1,0 +1,293 @@
+import { Image } from 'expo-image';
+import React, { useState } from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Calendar } from 'react-native-calendars';
+import type { DateRange } from '../../model/types';
+
+interface DateRangeSelectorProps {
+  dateRange: DateRange;
+  onDateRangeChange: (dateRange: DateRange) => void;
+}
+
+type DatePickerMode = 'start' | 'end';
+
+export const DateRangeSelector: React.FC<DateRangeSelectorProps> = ({
+  dateRange,
+  onDateRangeChange,
+}) => {
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [pickerMode, setPickerMode] = useState<DatePickerMode>('start');
+
+  // YYYYMMDD → YYYY-MM-DD 변환
+  const formatToCalendarDate = (dateStr: string): string => {
+    if (dateStr.length !== 8) return '';
+    return `${dateStr.substring(0, 4)}-${dateStr.substring(4, 6)}-${dateStr.substring(6, 8)}`;
+  };
+
+  // YYYY-MM-DD → YYYYMMDD 변환
+  const formatToApiDate = (dateStr: string): string => {
+    return dateStr.replace(/-/g, '');
+  };
+
+  // YYYYMMDD → MM월 DD일 형식으로 변환
+  const formatDisplayDate = (dateStr: string): string => {
+    if (dateStr.length !== 8) return '';
+    const month = parseInt(dateStr.substring(4, 6));
+    const day = parseInt(dateStr.substring(6, 8));
+    return `${month}월 ${day}일`;
+  };
+
+  // 오늘 날짜 (YYYY-MM-DD 형식)
+  const today = new Date().toISOString().slice(0, 10);
+
+  // 날짜 선택 핸들러
+  const handleDateSelect = (day: any) => {
+    const selectedApiDate = formatToApiDate(day.dateString);
+    
+    if (pickerMode === 'start') {
+      // 시작일 선택: 종료일이 시작일보다 이전이면 종료일도 같게 설정
+      const newEndDate = selectedApiDate > dateRange.endDate ? selectedApiDate : dateRange.endDate;
+      onDateRangeChange({
+        startDate: selectedApiDate,
+        endDate: newEndDate,
+      });
+    } else {
+      // 종료일 선택: 종료일이 시작일보다 이전이면 시작일도 같게 설정
+      const newStartDate = selectedApiDate < dateRange.startDate ? selectedApiDate : dateRange.startDate;
+      onDateRangeChange({
+        startDate: newStartDate,
+        endDate: selectedApiDate,
+      });
+    }
+    
+    setShowCalendar(false);
+  };
+
+  // 시작일 선택 버튼 클릭
+  const handleStartDatePress = () => {
+    setPickerMode('start');
+    setShowCalendar(true);
+  };
+
+  // 종료일 선택 버튼 클릭
+  const handleEndDatePress = () => {
+    setPickerMode('end');
+    setShowCalendar(true);
+  };
+
+  // 캘린더에 표시할 마크된 날짜들
+  const getMarkedDates = () => {
+    const startCalendarDate = formatToCalendarDate(dateRange.startDate);
+    const endCalendarDate = formatToCalendarDate(dateRange.endDate);
+    
+    const marked: any = {};
+    
+    if (startCalendarDate) {
+      marked[startCalendarDate] = {
+        selected: pickerMode === 'start',
+        selectedColor: pickerMode === 'start' ? '#3B82F6' : '#10B981',
+        textColor: 'white',
+      };
+    }
+    
+    if (endCalendarDate && endCalendarDate !== startCalendarDate) {
+      marked[endCalendarDate] = {
+        selected: pickerMode === 'end',
+        selectedColor: pickerMode === 'end' ? '#3B82F6' : '#EF4444',
+        textColor: 'white',
+      };
+    }
+    
+    return marked;
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.dateRangeContainer}>
+        {/* 시작일 선택 */}
+        <TouchableOpacity 
+          style={[styles.dateButton, styles.startDateButton]}
+          onPress={handleStartDatePress}
+        >
+          <View style={styles.dateButtonContent}>
+            <Image
+              source={require('@/assets/images/icons/calendar.png')}
+              style={styles.calendarIcon}
+              contentFit="contain"
+            />
+            <Text style={styles.dateButtonText}>
+              {dateRange.startDate ? formatDisplayDate(dateRange.startDate) : '시작날짜'}
+            </Text>
+          </View>
+        </TouchableOpacity>
+
+        {/* 구분자 */}
+        <Text style={styles.separator}>~</Text>
+
+        {/* 종료일 선택 */}
+        <TouchableOpacity 
+          style={[styles.dateButton, styles.endDateButton]}
+          onPress={handleEndDatePress}
+        >
+          <View style={styles.dateButtonContent}>
+            <Image
+              source={require('@/assets/images/icons/calendar.png')}
+              style={styles.calendarIcon}
+              contentFit="contain"
+            />
+            <Text style={styles.dateButtonText}>
+              {dateRange.endDate ? formatDisplayDate(dateRange.endDate) : '종료날짜'}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      </View>
+
+      {/* 캘린더 모달 */}
+      <Modal
+        visible={showCalendar}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={() => setShowCalendar(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.calendarContainer}>
+            {/* 모달 헤더 */}
+            <View style={styles.calendarHeader}>
+              <Text style={styles.calendarTitle}>
+                {pickerMode === 'start' ? '시작날짜 선택' : '종료날짜 선택'}
+              </Text>
+              <TouchableOpacity
+                style={styles.closeButton}
+                onPress={() => setShowCalendar(false)}
+              >
+                <Text style={styles.closeButtonText}>✕</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* 캘린더 */}
+            <Calendar
+              onDayPress={handleDateSelect}
+              markedDates={getMarkedDates()}
+              maxDate={today}
+              theme={{
+                backgroundColor: '#ffffff',
+                calendarBackground: '#ffffff',
+                textSectionTitleColor: '#b6c1cd',
+                selectedDayBackgroundColor: '#3B82F6',
+                selectedDayTextColor: '#ffffff',
+                todayTextColor: '#3B82F6',
+                dayTextColor: '#2d4150',
+                textDisabledColor: '#d9e1e8',
+                dotColor: '#00adf5',
+                selectedDotColor: '#ffffff',
+                arrowColor: '#3B82F6',
+                disabledArrowColor: '#d9e1e8',
+                monthTextColor: '#2d4150',
+                indicatorColor: '#3B82F6',
+                textDayFontFamily: 'System',
+                textMonthFontFamily: 'System',
+                textDayHeaderFontFamily: 'System',
+                textDayFontSize: 16,
+                textMonthFontSize: 18,
+                textDayHeaderFontSize: 14,
+              }}
+            />
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+    marginHorizontal: 20,
+    marginBottom: 16,
+  },
+  dateRangeContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  dateButton: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 12,
+    padding: 12,
+  },
+  startDateButton: {
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  endDateButton: {
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  dateButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  calendarIcon: {
+    width: 16,
+    height: 16,
+    marginRight: 8,
+  },
+  dateButtonText: {
+    color: '#374151',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  separator: {
+    color: '#6B7280',
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  calendarContainer: {
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 20,
+    width: '100%',
+    maxWidth: 350,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 10,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  calendarHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  calendarTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  closeButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#F3F4F6',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    fontSize: 16,
+    color: '#6B7280',
+    fontWeight: '600',
+  },
+});

--- a/src/features/account-history/ui/components/TransactionItem.tsx
+++ b/src/features/account-history/ui/components/TransactionItem.tsx
@@ -60,8 +60,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     paddingVertical: 16,
     paddingHorizontal: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
   },
   leftSection: {
     flex: 1,

--- a/src/features/account-history/ui/components/TransactionItem.tsx
+++ b/src/features/account-history/ui/components/TransactionItem.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { View, StyleSheet, Text } from 'react-native';
+import { Image } from 'expo-image';
+import type { FormattedTransaction } from '../../model/types';
+
+interface TransactionItemProps {
+  transaction: FormattedTransaction;
+}
+
+export const TransactionItem: React.FC<TransactionItemProps> = ({ transaction }) => {
+  const getAmountColor = (isDeposit: boolean) => {
+    return isDeposit ? '#10B981' : '#EF4444'; // 입금: 초록, 출금: 빨강
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.leftSection}>
+        {/* 거래 아이콘 */}
+        <View style={styles.iconContainer}>
+          <Image
+            source={require('@/assets/images/icons/settlement.png')}
+            style={styles.transactionIcon}
+            contentFit="contain"
+          />
+        </View>
+
+        {/* 거래 정보 */}
+        <View style={styles.transactionInfo}>
+          <Text style={styles.transactorName}>{transaction.transactorName}</Text>
+          {transaction.eventTitle && (
+            <Text style={styles.eventTitle}>{transaction.eventTitle}</Text>
+          )}
+          <Text style={styles.dateTime}>
+            {transaction.formattedDate} {transaction.formattedTime}
+          </Text>
+        </View>
+      </View>
+
+      {/* 거래 금액 */}
+      <View style={styles.rightSection}>
+        <Text style={[
+          styles.amount,
+          { color: getAmountColor(transaction.isDeposit) }
+        ]}>
+          {transaction.formattedAmount}
+        </Text>
+        <Text style={styles.afterBalance}>
+          잔액 {parseInt(transaction.transactionAfterBalance).toLocaleString()}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'white',
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  leftSection: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#F3F4F6',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  transactionIcon: {
+    width: 24,
+    height: 24,
+  },
+  transactionInfo: {
+    flex: 1,
+  },
+  transactorName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 2,
+  },
+  eventTitle: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginBottom: 2,
+  },
+  dateTime: {
+    fontSize: 12,
+    color: '#9CA3AF',
+  },
+  rightSection: {
+    alignItems: 'flex-end',
+  },
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 2,
+  },
+  afterBalance: {
+    fontSize: 12,
+    color: '#9CA3AF',
+  },
+});

--- a/src/features/main/ui/FeatureGrid.tsx
+++ b/src/features/main/ui/FeatureGrid.tsx
@@ -85,6 +85,11 @@ export const FeatureGrid: React.FC = () => {
       return;
     }
     
+    if (route === '/account') {
+      router.push('/account-history');
+      return;
+    }
+    
     // 나머지는 임시로 알림만 표시 (실제 페이지들은 나중에 구현)
     console.log(`Navigate to: ${route}`);
     // router.push(route); // 페이지 구현 후 활성화


### PR DESCRIPTION
- 계좌 내역 페이지를 구현했습니다. 
```
📁 계좌 내역 (Account History) 기능
├── 📁 app/account-history/                    # 라우팅 설정
│   ├── _layout.tsx                            # 스택 네비게이션 레이아웃 (헤더 숨김)
│   └── index.tsx                              # 페이지 진입점, AccountHistoryScreen 렌더링
│
└── 📁 src/features/account-history/           # Feature-Sliced Design 구조
├── 📁 api/
│   └── accountHistoryApi.ts               # API 호출 함수들 (실제 API + Mock API)
│
├── 📁 model/
│   ├── types.ts                           # 타입 정의 (DTO, 요청/응답, 포맷팅된 데이터)
│   └── accountHistoryStore.ts             # Zustand 상태 관리 (데이터 로드, 날짜 그룹핑 로직)
│
└── 📁 ui/
├── AccountHistoryScreen.tsx           # 메인 화면 (SectionList, 높이 제한 적용)
└── 📁 components/
├── AccountHistoryHeader.tsx       # 상단 헤더 컴포넌트

├── DateRangeSelector.tsx          # 날짜 범위 선택 컴포넌트
└── TransactionItem.tsx            # 개별 거래 항목 컴포넌트
```